### PR TITLE
Add CA certificate profiles for Stritzinger and GRiSP2

### DIFF
--- a/config/sys.config
+++ b/config/sys.config
@@ -4,5 +4,14 @@
       i2c_bus => 0,
       i2c_address => 16#6C}
   },
-  {templates, [{{0, 0}, test}]}
+  %% template meta data to use for certificate handling,
+  %% a '{template ID, chain ID}' tuple is stored in the
+  %% secure element when the certificate is written and
+  %% then used to identify the template again when the
+  %% certificate is read from the secure element
+  {templates, [
+    {{0, 0}, stritzinger_root},
+    {{1, 0}, grisp2_intermediate},
+    {{2, 0}, grisp2_device}
+  ]}
 ]}].

--- a/src/grisp_cryptoauth_cert.erl
+++ b/src/grisp_cryptoauth_cert.erl
@@ -314,10 +314,13 @@ ext_subKeyId(PubKeyBlob) ->
        extnValue = crypto:hash(sha, PubKeyBlob)}.
 
 
+%% see RFC5280 4.2.1.3
+%% for CAs the extension SHOULD be critical
 ext_keyUsage(UsageList) ->
     #'Extension'{
        extnID = ?'id-ce-keyUsage',
-       extnValue = UsageList}.
+       extnValue = UsageList,
+       critical = lists:member(keyCertSign, UsageList)}.
 
 
 ext_extKeyUsage(client) ->
@@ -330,10 +333,14 @@ ext_extKeyUsage(server) ->
        extnValue = [?'id-kp-serverAuth']}.
 
 
+%% see RFC5280 4.2.1.9
+%% for CAs this extension MUST be critical, also
+%% we don't care about validation path lengths
 ext_isCa(IsCA) ->
     #'Extension'{
        extnID = ?'id-ce-basicConstraints',
-       extnValue = #'BasicConstraints'{cA = IsCA}}.
+       extnValue = #'BasicConstraints'{cA = IsCA},
+       critical = IsCA}.
 
 
 calc_expire_years(#'Validity'{notAfter = ?MAX_NOT_AFTER}) ->

--- a/src/grisp_cryptoauth_profile.erl
+++ b/src/grisp_cryptoauth_profile.erl
@@ -2,7 +2,9 @@
 
 -include_lib("public_key/include/public_key.hrl").
 
--export([tls_client/5]).
+-export([tls_client/5,
+         intermediate_ca/5,
+         root_ca/4]).
 
 
 tls_client(IssuerCert, {IssueDate, ExpireYears}, Subject, DERPubKey, GrispMeta) ->
@@ -17,10 +19,44 @@ tls_client(IssuerCert, {IssueDate, ExpireYears}, Subject, DERPubKey, GrispMeta) 
         subject = grisp_cryptoauth_cert:distinguished_name(Subject),
         subjectPublicKeyInfo = grisp_cryptoauth_cert:subPubKeyInfo(DERPubKey),
         extensions = grisp_cryptoauth_cert:build_standard_ext([
-            {ext_isCa, false},
             {ext_subKeyId, DERPubKey},
             {ext_authKeyId, IssuerCert},
             {ext_keyUsage, [digitalSignature, keyAgreement]},
             {ext_extKeyUsage, client}
         ]) ++ [grisp_cryptoauth_cert:build_grisp_ext(GrispMeta)]
+    }.
+
+
+intermediate_ca(IssuerCert, Serial, {IssueDate, ExpireYears}, Subject, DERPubKey) ->
+    IssuerCertTBS = IssuerCert#'OTPCertificate'.tbsCertificate,
+    #'OTPTBSCertificate'{
+        version = v3,
+        serialNumber = Serial,
+        signature = grisp_cryptoauth_cert:sigAlg(),
+        issuer = IssuerCertTBS#'OTPTBSCertificate'.subject,
+        validity = grisp_cryptoauth_cert:validity(IssueDate, ExpireYears),
+        subject = grisp_cryptoauth_cert:distinguished_name(Subject),
+        subjectPublicKeyInfo = grisp_cryptoauth_cert:subPubKeyInfo(DERPubKey),
+        extensions = grisp_cryptoauth_cert:build_standard_ext([
+            {ext_isCa, true},
+            {ext_subKeyId, DERPubKey},
+            {ext_authKeyId, IssuerCert},
+            {ext_keyUsage, [keyCertSign, cRLSign]}
+        ])
+    }.
+
+
+root_ca(Serial, {IssueDate, ExpireYears}, Subject, DERPubKey) ->
+    #'OTPTBSCertificate'{
+        version = v3,
+        serialNumber = Serial,
+        signature = grisp_cryptoauth_cert:sigAlg(),
+        issuer = grisp_cryptoauth_cert:distinguished_name(Subject),
+        validity = grisp_cryptoauth_cert:validity(IssueDate, ExpireYears),
+        subject = grisp_cryptoauth_cert:distinguished_name(Subject),
+        subjectPublicKeyInfo = grisp_cryptoauth_cert:subPubKeyInfo(DERPubKey),
+        extensions = grisp_cryptoauth_cert:build_standard_ext([
+            {ext_isCa, true},
+            {ext_subKeyId, DERPubKey}
+        ])
     }.

--- a/src/grisp_cryptoauth_profile.erl
+++ b/src/grisp_cryptoauth_profile.erl
@@ -14,7 +14,7 @@ tls_client(IssuerCert, {IssueDate, ExpireYears}, Subject, DERPubKey, GrispMeta) 
         signature = grisp_cryptoauth_cert:sigAlg(),
         issuer = IssuerCertTBS#'OTPTBSCertificate'.subject,
         validity = grisp_cryptoauth_cert:validity(IssueDate, ExpireYears),
-        subject = Subject,
+        subject = grisp_cryptoauth_cert:distinguished_name(Subject),
         subjectPublicKeyInfo = grisp_cryptoauth_cert:subPubKeyInfo(DERPubKey),
         extensions = grisp_cryptoauth_cert:build_standard_ext([
             {ext_isCa, false},

--- a/src/grisp_cryptoauth_template.erl
+++ b/src/grisp_cryptoauth_template.erl
@@ -1,28 +1,67 @@
 -module(grisp_cryptoauth_template).
 
--export([grisp2/0, test/0]).
+-export([grisp2_device/0,
+         grisp2_intermediate/0,
+         stritzinger_root/0,
+         test/0]).
 
 
-%% Default GRiSP2 certificate.
-grisp2() ->
+-define(SERIAL_STRITZINGER_ROOT_CA, 1).
+-define(SERIAL_INTERMEDIATE_CA, 2).
+
+
+%% GRiSP2 device certificate.
+grisp2_device() ->
+    %% needs to be replaced by GRiSP2 intermediate CA certificate
     IssuerCert = grisp_cryptoauth_cert:decode_pem(
                    grisp_cryptoauth_known_certs:test_intermediate()),
-    IssueDateInfo = {{{2021,9,1}, {0,0,0}}, no_expiration},
+    Validity = {{{2021,9,1}, {0,0,0}}, no_expiration},
     {ok, DERPubKey} = grisp_cryptoauth:public_key(primary),
     {ok, GrispMeta} = grisp_hw:eeprom_read(),
     Serial = maps:get(grisp_serial, GrispMeta),
     Subject = #{'CN' => "GRiSP2", 'serialNumber' => integer_to_list(Serial)},
-    grisp_cryptoauth_profile:tls_client(IssuerCert, IssueDateInfo,
-                                        Subject, DERPubKey, GrispMeta).
+    grisp_cryptoauth_profile:tls_client(IssuerCert, Validity, Subject, DERPubKey, GrispMeta).
 
 
-%% Just used for testing, no access to
-%% issuer certificate, Secure Element
-%% or EEPROM needed.
+%% GRiSP2 intermediate CA certificate.
+grisp2_intermediate() ->
+    %% needs to be replaced by Stritzinger root CA certificate
+    IssuerCert = grisp_cryptoauth_cert:decode_pem(
+                   grisp_cryptoauth_known_certs:test_intermediate()),
+    Validity = {{{2021,9,1}, {0,0,0}}, no_expiration},
+    {ok, DERPubKey} = grisp_cryptoauth:public_key(primary),
+    Serial = ?SERIAL_INTERMEDIATE_CA,
+    Subject = #{
+        'CN' => "GRiSP2 CA",
+        'O'  => "Dipl.Phys. Peer Stritzinger GmbH",
+        'OU' => "www.grisp.org",
+        emailAddress => "grisp@stritzinger.com"
+    },
+    grisp_cryptoauth_profile:intermediate_ca(IssuerCert, Serial, Validity, Subject, DERPubKey).
+
+
+%% Stritzinger root CA certificate.
+stritzinger_root() ->
+    Validity = {{{2021,9,1}, {0,0,0}}, no_expiration},
+    {ok, DERPubKey} = grisp_cryptoauth:public_key(primary),
+    Serial = ?SERIAL_STRITZINGER_ROOT_CA,
+    Subject = #{
+        'CN' => "Stritzinger Root CA",
+        'O'  => "Dipl.Phys. Peer Stritzinger GmbH",
+        'OU' => "www.stritzinger.com",
+        'C'  => "DE",
+        'L'  => "Munich",
+        emailAddress => "info@stritzinger.com"
+    },
+    grisp_cryptoauth_profile:root_ca(Serial, Validity, Subject, DERPubKey).
+
+
+%% Just used for testing, no access to issuer certificate, Secure Element
+%% or EEPROM needed. Compile .erl files locally and execute this function.
 test() ->
     IssuerCert = grisp_cryptoauth_cert:decode_pem(
                    grisp_cryptoauth_known_certs:test_intermediate()),
-    IssueDateInfo = {{{2021,9,1}, {0,0,0}}, no_expiration},
+    Validity = {{{2021,9,1}, {0,0,0}}, no_expiration},
     Subject = #{'CN' => "client"},
     DERPubKey = <<4,109,220,77,238,124,58,236,54,132,168,190,179,110,123,161,
                   140,75,181,236,209,197,123,110,169,233,214,7,127,204,182,
@@ -36,5 +75,4 @@ test() ->
         grisp_pcb_variant   => 1,
         grisp_batch         => 1,
         grisp_prod_date     => {{2021,9,1}, {0,0,0}}},
-    grisp_cryptoauth_profile:tls_client(IssuerCert, IssueDateInfo,
-                                        Subject, DERPubKey, GrispMeta).
+    grisp_cryptoauth_profile:tls_client(IssuerCert, Validity, Subject, DERPubKey, GrispMeta).

--- a/src/grisp_cryptoauth_template.erl
+++ b/src/grisp_cryptoauth_template.erl
@@ -11,9 +11,7 @@ grisp2() ->
     {ok, DERPubKey} = grisp_cryptoauth:public_key(primary),
     {ok, GrispMeta} = grisp_hw:eeprom_read(),
     Serial = maps:get(grisp_serial, GrispMeta),
-    Subject = grisp_cryptoauth_cert:distinguished_name(
-                #{'id-at-commonName' => "GRiSP2 " ++ integer_to_list(Serial)}
-               ),
+    Subject = #{'CN' => "GRiSP2", 'serialNumber' => integer_to_list(Serial)},
     grisp_cryptoauth_profile:tls_client(IssuerCert, IssueDateInfo,
                                         Subject, DERPubKey, GrispMeta).
 
@@ -25,9 +23,7 @@ test() ->
     IssuerCert = grisp_cryptoauth_cert:decode_pem(
                    grisp_cryptoauth_known_certs:test_intermediate()),
     IssueDateInfo = {{{2021,9,1}, {0,0,0}}, no_expiration},
-    Subject = grisp_cryptoauth_cert:distinguished_name(
-                #{'id-at-commonName' => "client"}
-               ),
+    Subject = #{'CN' => "client"},
     DERPubKey = <<4,109,220,77,238,124,58,236,54,132,168,190,179,110,123,161,
                   140,75,181,236,209,197,123,110,169,233,214,7,127,204,182,
                   215,77,227,214,133,58,247,44,163,184,81,162,36,49,11,17,252,


### PR DESCRIPTION
Stritzinger is represented through a root certificate while Seawater is supposed to be represented through an intermediate CA certificate, signed by the Stritzinger root CA private key. GRiSP2 device certificates are then signed by the Seawater intermediate CA private key.