### PR TITLE
Adapt the sign fun to future OTP feature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to
 
 ## [Unreleased]
 
+- Add sign_fun/3 to support OTP 27 new key option for secure Elements
+
 ## [2.2.0] - 2024-06-25
 
 - Bump grisp to 2.5.0

--- a/README.md
+++ b/README.md
@@ -36,12 +36,21 @@ More to come :).
 
 Setting up TLS
 --------------
-
-There is a patch necessary to make use of `grisp_cryptoauth` for TLS. This
-patch is included in this repository and is tested for Erlang `23.3.4.10`.
-
 Erlang's `ssl` library is used for setting up TLS/mTLS. For the device
 you need to honor at least the following options:
+#### OTP >= 27
+```
+{certs_keys, [#{
+    cert => ClientChain,
+    key => #{
+        algorithm => ecdsa,
+        sign_fun => fun grisp_cryptoauth:sign_fun/3
+    }
+}]}
+```
+#### Legacy tls options: OTP =< 26
+There is a patch necessary to make use of `grisp_cryptoauth` for TLS. This
+patch is included in this repository and is tested for Erlang `23.3.4.10`, this patch has been adapted and maintained until OTP 26. We do not apply any SSL patch as form OTP 27.
 
 ```
 %% device certificate

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ you need to honor at least the following options:
 ```
 #### Legacy tls options: OTP =< 26
 There is a patch necessary to make use of `grisp_cryptoauth` for TLS. This
-patch is included in this repository and is tested for Erlang `23.3.4.10`, this patch has been adapted and maintained until OTP 26. We do not apply any SSL patch as form OTP 27.
+patch is included in this repository and is tested for Erlang `23.3.4.10`, this patch has been adapted and maintained until OTP 26. We do not apply any SSL patch from OTP 27.
 
 ```
 %% device certificate

--- a/src/grisp_cryptoauth.erl
+++ b/src/grisp_cryptoauth.erl
@@ -95,6 +95,14 @@ sign(Context, secondary_3, Msg) ->
 sign_fun(Msg) ->
     sign_fun(Msg, sha256, []).
 
+%% Active from OTP 27 as key sign_fun
+%{certs_keys, [#{
+%   cert => ClientChain,
+%   key => #{
+%       algorithm => ecdsa,
+%       sign_fun => fun grisp_cryptoauth:sign_fun/3
+%   }
+% }]}
 sign_fun(Msg, sha256, _Opts)  ->
     {ok, Sig} = sign(primary, Msg),
     <<R:32/big-unsigned-integer-unit:8, S:32/big-unsigned-integer-unit:8>> = Sig,

--- a/src/grisp_cryptoauth.erl
+++ b/src/grisp_cryptoauth.erl
@@ -3,6 +3,7 @@
 %% Main API
 -export([sign/2,
          sign_fun/1,
+         sign_fun/3,
          verify/3,
          public_key/1,
          refresh_key/1,
@@ -92,6 +93,9 @@ sign(Context, secondary_3, Msg) ->
 %% Used within patched ssl library for private (primary) key:
 %% {key, #{algorithm => ecdsa, sign_fun => {grisp_cryptoauth, sign_fun}}}
 sign_fun(Msg) ->
+    sign_fun(Msg, sha256, []).
+
+sign_fun(Msg, sha256, _Opts)  ->
     {ok, Sig} = sign(primary, Msg),
     <<R:32/big-unsigned-integer-unit:8, S:32/big-unsigned-integer-unit:8>> = Sig,
     public_key:der_encode('ECDSA-Sig-Value', #'ECDSA-Sig-Value'{r = R, s = S}).


### PR DESCRIPTION
## CONTEXT
OTP 27 landed with a new configuration option for TLS that now supports our secure element. 
This means no patches are needed but a different sign function needs to be used.

Using the new OTP will also require different TLS options so that should be documented in this app README.
